### PR TITLE
Change distance to Kernel Characteristic Function Estimator

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.1.1"
 ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
+SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
 ComponentArrays = "^0.13"

--- a/src/Distance.jl
+++ b/src/Distance.jl
@@ -1,3 +1,10 @@
+function distance_constant(observations::AV{<:Real}, b::Real)::Real
+    sum(
+        normal(observations[n], observations[m], 2 * b^2)
+        for n in eachindex(observations), m in eachindex(observations)
+    ) / (length(observations)^2)
+end
+
 """
 $TYPEDSIGNATURES
 
@@ -15,7 +22,10 @@ similar to density smoothing in regular KDE.
 - Lower `b` (maybe zero) => more rough empirical CF =>
 more overfitting => greater variance.
 """
-function distance(p::AV{<:Real}, mu::AV{<:Real}, sigma::AV{<:Real}, observations::AV{<:Real}, b::Real)::Real
+function distance(
+    p::AV{<:Real}, mu::AV{<:Real}, sigma::AV{<:Real}, observations::AV{<:Real}, b::Real,
+    constant::Real=distance_constant(observations, b)
+)::Real
     N = length(observations)
 
     loss = -2/N  * sum(
@@ -27,7 +37,7 @@ function distance(p::AV{<:Real}, mu::AV{<:Real}, sigma::AV{<:Real}, observations
         for j in eachindex(p), k in eachindex(p)
     )
     
-    loss + penalty
+    loss + penalty + constant
 end
 
 """
@@ -36,8 +46,11 @@ $TYPEDSIGNATURES
 Same as `distance`, but all mixture parameters
 come from one vector. Used for optimization.
 """
-function distance_one_arg(θ::AV{<:Real}, observations::AV{<:Real}, b::Real)
+function distance_one_arg(
+    θ::AV{<:Real}, observations::AV{<:Real}, b::Real,
+    constant::Real=distance_constant(observations, b)
+)
 	p, mu, sigma = get_mix_params(θ)
 
-	distance(p, mu, sigma, observations, b)
+	distance(p, mu, sigma, observations, b, constant)
 end

--- a/src/Fit.jl
+++ b/src/Fit.jl
@@ -151,5 +151,8 @@ $TYPEDSIGNATURES
 Convenience wrapper for `fit_cecf!` to quickly fit mixtures of `K` components
 without creating the `GaussianMixture` object.
 """
-fit_cecf(K::Integer, data::AV{<:Real}; b::Real) =
-    fit_cecf!(GaussianMixture(K), data; b)
+fit_cecf(K::Integer, data::AV{<:Real}; b::Real, kwargs...) =
+    fit_cecf!(GaussianMixture(K), data; b, kwargs...)
+
+fit = fit_cecf
+fit! = fit_cecf!

--- a/src/GaussianMixturesCECF.jl
+++ b/src/GaussianMixturesCECF.jl
@@ -4,7 +4,7 @@ $(README)
 $(EXPORTS)
 """
 module GaussianMixturesCECF
-export GaussianMixture, fit_cecf!, fit!, fit_cecf, fit, get_mix_params
+export GaussianMixture, fit_cecf!, fit!, fit_cecf, fit
 
 using DocStringExtensions
 using Optim, ComponentArrays
@@ -14,5 +14,6 @@ const AV = AbstractVector{T} where T
 include("Misc.jl")
 include("Distance.jl")
 include("Fit.jl")
+include("Metrics.jl")
 
 end # module

--- a/src/GaussianMixturesCECF.jl
+++ b/src/GaussianMixturesCECF.jl
@@ -4,7 +4,7 @@ $(README)
 $(EXPORTS)
 """
 module GaussianMixturesCECF
-export GaussianMixture, fit_cecf!, fit_cecf, get_mix_params
+export GaussianMixture, fit_cecf!, fit!, fit_cecf, fit, get_mix_params
 
 using DocStringExtensions
 using Optim, ComponentArrays

--- a/src/Metrics.jl
+++ b/src/Metrics.jl
@@ -1,0 +1,171 @@
+module Metrics
+export neg_log_likelihood, cauchy_schwarz, wasserstein
+
+import ..AV, ..normal
+using ComponentArrays, DocStringExtensions
+import SpecialFunctions: erf
+
+# ========== Log-likelihood ==========
+
+"""
+$TYPEDSIGNATURES
+
+Log-likelihood of the mixture specified by `params`
+given `data` used to fit the mixture.
+
+__Higher is better__.
+"""
+function log_likelihood(params::ComponentVector, data::AV{<:Real})::Real
+    p, mu, sigma = params.p, params.mu, params.sigma
+
+    sum(
+        sum(
+            p[k] * normal(x, mu[k], sigma[k]^2)
+            for k in eachindex(p)
+        ) |> log
+        for x in data
+    )
+end
+
+"""
+$TYPEDSIGNATURES
+
+Negative log-likelihood of the mixture specified by `params`
+given `data` used to fit the mixture.
+
+__Lower is better__.
+"""
+neg_log_likelihood(params::ComponentVector, data::AV{<:Real})::Real =
+    -log_likelihood(params, data)
+
+
+# ========== Cauchy-Schwarz divergence ==========
+
+function cauchy_schwarz_part(p::AV, mu::AV, tau::AV)
+    s1 = sum(@. p^2 * sqrt(tau / (2π)) / sqrt(2))
+    s2 = sum(
+        sum(
+            p[m] * p[m_] * normal(
+                mu[m], mu[m_], 1/tau[m] + 1/tau[m_]
+            )
+            for m_ in 1:(m-1); init=0.0
+        )
+        for m in eachindex(p); init=0.0
+    )
+
+    0.5 * log(s1 + 2s2)
+end
+
+"""
+$TYPEDSIGNATURES
+
+Cauchy-Schwarz distance between the probability density function (PDF)
+of the mixture specified by `params` and the kernel density estimate
+of `data` with window size `h>0`.
+
+__Lower is better__. Minimum: 0.
+
+Paper: Kampa, Kittipat, Erion Hasanbelliu, and Jose C. Principe.
+"Closed-Form Cauchy-Schwarz PDF Divergence for Mixture of Gaussians."
+In The 2011 International Joint Conference on Neural Networks, 2578–85.
+San Jose, CA, USA: IEEE, 2011. https://doi.org/10.1109/IJCNN.2011.6033555.
+"""
+function cauchy_schwarz(params::ComponentVector, data::AV{<:Real}, h::Real)::Real
+    @assert h > 0
+    N = length(data)
+    p, mu, sigma = params.p, params.mu, params.sigma
+    tau = @. 1 / sigma^2
+    tau_data = 1 / h^2
+
+    a = sum(
+        p[m] * 1/N * normal(
+            mu[m], x, 1/tau[m] + 1/tau_data
+        )
+        for m in eachindex(p), x in data
+    ) |> log |> -
+
+    (
+        a
+        + cauchy_schwarz_part(p, mu, tau) # fitted mixture
+        + cauchy_schwarz_part(
+            fill(1/N, N), data, fill(tau_data, N)
+        ) # KDE of data (also mixture, but with common std `h`)
+    )
+end
+
+
+# ========== 1-Wasserstein ==========
+
+normal_CDF(x::Real) = (1 + erf(x / sqrt(2))) / 2
+normal_CDF(x::Real, mu::Real, sigma::Real) = normal_CDF((x - mu) / sigma)
+mix_CDF(x::Real, p::AV{<:Real}, mu::AV{<:Real}, sigma::AV{<:Real}) =
+    sum(
+        p_ * normal_CDF(x, mu_, sigma_)
+        for (p_, mu_, sigma_) in zip(p, mu, sigma)
+    )
+
+struct EmpiricalCDF{T<:Real, D<:Integer}
+    sorted_samples::Vector{T}
+    CDF_values::Base.OneTo{D} # unnormalized!
+
+    function EmpiricalCDF(samples::AV{T}) where T<:Real
+        CDF_values = eachindex(samples)
+        
+        new{T, eltype(CDF_values)}(sort(samples), CDF_values)
+    end
+end
+
+function (cdf::EmpiricalCDF{T})(x::Real) where T<:Real
+    if x < cdf.sorted_samples[begin]
+        return zero(T)
+    elseif x > cdf.sorted_samples[end]
+        return one(T)
+    end
+
+    GREATEST_CDF::T = T(cdf.CDF_values[end])
+
+    for (i, sample) in enumerate(cdf.sorted_samples)
+        (x < sample) && return cdf.CDF_values[i-1] / GREATEST_CDF
+    end
+end
+
+function integrate_simpson(f::Function, integration_range::StepRangeLen{<:AbstractFloat})
+    @assert iseven(length(integration_range))
+
+    n = length(integration_range)
+    xs = range(integration_range[begin], integration_range[end], n+1)
+    Δx = xs[2] - xs[1]
+
+    S1 = sum(f(x) for x in xs[2:2:n])
+    S2 = sum(f(x) for x in xs[3:2:n-1])
+
+    Δx/3 * (f(xs[begin]) + 4S1 + 2S2 + f(xs[end]))
+end
+
+function wasserstein(params::ComponentVector, F_data, integration_range::StepRangeLen)
+    F_model(x::Real) = mix_CDF(x, params.p, params.mu, params.sigma)
+
+    integrate_simpson(
+        x->abs(F_data(x) - F_model(x)),
+        integration_range
+    )
+end
+
+"""
+$TYPEDSIGNATURES
+
+1-Wasserstein distance between the cumulative distribution function (CDF)
+of the mixture specified by `params` and the empirical CDF of the `data`.
+
+__Lower is better__. Minimum: 0.
+"""
+function wasserstein(params::ComponentVector, data::AV; npoints::Integer=5000, mult::Real=10)::Real
+    @assert npoints > 0
+    @assert mult > 0
+    min_, max_ = minimum(data), maximum(data)
+    the_range = range(min_ - mult*abs(min_), max_ + mult*abs(max_), npoints)
+
+    wasserstein(params, EmpiricalCDF(data), the_range)
+end
+
+end # module


### PR DESCRIPTION
In (Xu & Knight, 2010) the integral converges because the distance is multiplied by a weight function `w(t) = exp(-b * t^2)`. However, this renders the hyperparameter `b` difficult to interpret. Furthermore, `b` will affect both the model CF and the empirical one, so it'll be hard to know how to set `b` "correctly" and how it affects the resulting estimates.

We can obtain the same effect (the integral converges and can be computed analytically) by considering the same distance, but between the model CF and the CF of a kernel density estimator (KDE) for the data:

```
sum(p_k exp(it mu_k - 1/2 * sigma_k^2 t^2)) - sum(1/N exp(it x_n - 1/2 * b^2 t^2))
```

Now `b` is the window size of the KDE, and the smaller it is, the closer the "Kernel Characteristic Function Estimator" is to the empirical characteristic function (ECF).

The integral exists and can be computed analytically, like in (Xu & Knight, 2010).